### PR TITLE
ci: pin external GitHub Actions

### DIFF
--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -17,14 +17,14 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           fetch-depth: 1
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
       - name: Docker meta alpine
         id: meta_alpine
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175
         with:
           images: |
             ghcr.io/chronicleprotocol/challenger
@@ -36,9 +36,9 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55
       - name: Login to ghcr.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -48,7 +48,7 @@ jobs:
         run: |
           echo "VERSION=${GITHUB_REF##*/v}" >> $GITHUB_ENV
       - name: Build and push (alpine)
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9
         with:
           push: true
           context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           echo "version is: ${{ env.SWS_VERSION }}"
       - name: Create GitHub release
         id: release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -129,12 +129,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           fetch-depth: 1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
@@ -180,7 +180,7 @@ jobs:
           fi
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: nightly
           components: rustfmt
@@ -27,11 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
       - run: curl -L https://foundry.paradigm.xyz | bash
@@ -49,11 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@clippy
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      - uses: dtolnay/rust-toolchain@e7a32da269276b4d9cb3a0343133a168355ab751
         with:
           toolchain: nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           cache-on-failure: true
       - run: cargo clippy --workspace --all-targets --all-features
@@ -65,8 +65,8 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.22.7
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: crate-ci/typos@cfe759ac8dd421e203cc293a373396fbc6fe0d4b
         with:
           config: ./typos.toml
           isolated: true


### PR DESCRIPTION
Pins third-party GitHub Actions `uses:` references to full commit SHAs.

Context: RFC-043 GitHub organization security hardening.

This PR does not change GitHub org settings, branch protection, or workflow permissions.

Pinned references:
- `.github/workflows/release.docker.yml:20` `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `.github/workflows/release.docker.yml:24` `docker/setup-qemu-action@v2` -> `docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7`
- `.github/workflows/release.docker.yml:27` `docker/metadata-action@v4` -> `docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175`
- `.github/workflows/release.docker.yml:39` `docker/setup-buildx-action@v2` -> `docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55`
- `.github/workflows/release.docker.yml:41` `docker/login-action@v2` -> `docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc`
- `.github/workflows/release.docker.yml:51` `docker/build-push-action@v4` -> `docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9`
- `.github/workflows/release.yml:28` `actions/create-release@v1` -> `actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e`
- `.github/workflows/release.yml:132` `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `.github/workflows/release.yml:137` `dtolnay/rust-toolchain@stable` -> `dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8`
- `.github/workflows/release.yml:183` `softprops/action-gh-release@v1` -> `softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844`
- `.github/workflows/tests.yml:18` `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `.github/workflows/tests.yml:19` `dtolnay/rust-toolchain@stable` -> `dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8`
- `.github/workflows/tests.yml:30` `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `.github/workflows/tests.yml:31` `dtolnay/rust-toolchain@stable` -> `dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8`
- `.github/workflows/tests.yml:34` `Swatinem/rust-cache@v2` -> `Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32`
- `.github/workflows/tests.yml:52` `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `.github/workflows/tests.yml:53` `dtolnay/rust-toolchain@clippy` -> `dtolnay/rust-toolchain@e7a32da269276b4d9cb3a0343133a168355ab751`
- `.github/workflows/tests.yml:56` `Swatinem/rust-cache@v2` -> `Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32`
- `.github/workflows/tests.yml:68` `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5`
- `.github/workflows/tests.yml:69` `crate-ci/typos@v1.22.7` -> `crate-ci/typos@cfe759ac8dd421e203cc293a373396fbc6fe0d4b`