### PR TITLE
ci: declare explicit GitHub token permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+"
 
+
+permissions:
+  contents: write
 jobs:
   create-release:
     name: create-release


### PR DESCRIPTION
## Summary
- add explicit least-privilege `GITHUB_TOKEN` permissions before the org default is switched to read-only
- keep write scopes limited to workflows that currently rely on default-token writes

## Permission changes
- `.github/workflows/release.yml`: contents: write (softprops/action-gh-release creates GitHub releases with GITHUB_TOKEN)

## Verification
- generated from the refreshed RFC-043 GitHub Actions token write-permission inventory
- intended to preserve behavior after org-level default token permissions become read-only