### PR TITLE
ci: use central release image signing

### DIFF
--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -14,6 +14,9 @@ jobs:
       id-token: write
       packages: write
       contents: read
+    outputs:
+      digest: ${{ steps.build-and-push.outputs.digest }}
+      tags: ${{ steps.meta_alpine.outputs.tags }}
     timeout-minutes: 120
     steps:
       - name: Checkout repository
@@ -46,8 +49,9 @@ jobs:
       - name: Prepare Docker envs
         shell: bash
         run: |
-          echo "VERSION=${GITHUB_REF##*/v}" >> $GITHUB_ENV
+          echo "VERSION=${GITHUB_REF##*/v}" >> "$GITHUB_ENV"
       - name: Build and push (alpine)
+        id: build-and-push
         uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9
         with:
           push: true
@@ -57,3 +61,18 @@ jobs:
           tags: ${{ steps.meta_alpine.outputs.tags }}
           build-args: |
             VERSION=${{ env.VERSION }}
+
+  sign_release_image:
+    name: Sign release image
+    needs: docker-image-alpine
+    if: ${{ startsWith(github.ref, 'refs/tags/') && needs.docker-image-alpine.outputs.digest != '' }}
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    uses: chronicleprotocol/actions-workflows/.github/workflows/cosign-sign-and-verify.yaml@main
+    with:
+      digest: ${{ needs.docker-image-alpine.outputs.digest }}
+      tags: ${{ needs.docker-image-alpine.outputs.tags }}
+      repository: ${{ github.repository }}
+      ref: ${{ github.ref }}


### PR DESCRIPTION
## Summary
- Wire this repo image publishing workflow into the shared RFC-044.3 release image signing path.
- Use the central Docker builder or signer from `chronicleprotocol/actions-workflows`.
- Keep signing release-only on tag paths and preserve existing build inputs/tags.

## Verification
- `actionlint` on changed workflow file(s)
- `git diff --check origin/main`
- Local pre-push hooks were allowed to run; any failures were unrelated repo test/setup failures, not workflow syntax.