### PR TITLE
ci: sign releases with the embedded signer (RFC-044.4 WS3a follow-up)

### DIFF
--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -70,9 +70,10 @@ jobs:
       contents: read
       id-token: write
       packages: write
-    uses: chronicleprotocol/actions-workflows/.github/workflows/cosign-sign-and-verify.yaml@main
+    # Self-signer embedded in this repo. Pinned @main so the cosign keyless SAN is
+    # sign-image.yaml@refs/heads/main (invariant of this tag build), matching the
+    # Kyverno verify-chronicle-release-images enforce identity.
+    uses: chronicleprotocol/challenger-rs/.github/workflows/sign-image.yaml@main
     with:
       digest: ${{ needs.docker-image-alpine.outputs.digest }}
       tags: ${{ needs.docker-image-alpine.outputs.tags }}
-      repository: ${{ github.repository }}
-      ref: ${{ github.ref }}


### PR DESCRIPTION
## What

Rewires the `sign_release_image` job in `release.docker.yml` to call this repo's own
embedded signer instead of the private `actions-workflows` reusable.

## Why

This repo is public; GitHub forbids public repos from calling reusable workflows in
private repos, so `cosign-sign-and-verify.yaml@main` is unreachable and the sign job
could never run (the build job `docker-image-alpine` is inline and already works).

The signer is referenced as `chronicleprotocol/challenger-rs/.github/workflows/sign-image.yaml@main`,
not the relative `./` form, on purpose: the `@main` pin makes the cosign keyless SAN
`sign-image.yaml@refs/heads/main`, invariant of the (tag) build ref. That matches the
Kyverno `verify-chronicle-release-images` enforce identity. A relative call would sign
under `@refs/tags/vX.Y.Z` and be rejected by the Deny policy.

`repository`/`ref` inputs are dropped; the embedded signer self-verifies against its own
`github.repository`/`github.ref`.

## Test plan

- [ ] Tag a release (`vX.Y.Z`): `docker-image-alpine` builds + pushes (unchanged), then
      `sign_release_image` signs via the local signer.
- [ ] `cosign verify ghcr.io/chronicleprotocol/challenger@<digest>` against
      `.../challenger-rs/.github/workflows/sign-image.yaml@refs/heads/main` passes.
- [ ] Pod admission of the new image is allowed by the enforce IVP.
